### PR TITLE
Add English meaning and user id to uploads table; closes #27

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -1,4 +1,9 @@
 class Upload < ActiveRecord::Base
+  belongs_to :user
+  validates :url, presence: true
+  validates :meaning, presence: true
+  validates :user_id, presence: true
+
   def self.with_meaning
     where.not(meaning: ["no meaning", ""])
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,10 @@
 class User < ActiveRecord::Base
+  has_many :uploads
+  validates :name, presence: true
+  validates :first_name, presence: true
+  validates :email, presence: true
+  validates :provider, presence: true
+
   def self.find_or_create_from_auth(auth)
     user = User.find_or_create_by(provider: auth.provider, uid: auth.uid)
     user.email = auth.info.email

--- a/db/migrate/20150313020726_add_meaning_en_to_uploads.rb
+++ b/db/migrate/20150313020726_add_meaning_en_to_uploads.rb
@@ -1,0 +1,5 @@
+class AddMeaningEnToUploads < ActiveRecord::Migration
+  def change
+    add_column :uploads, :meaning_en, :string
+  end
+end

--- a/db/migrate/20150313020840_add_user_id_to_uploads.rb
+++ b/db/migrate/20150313020840_add_user_id_to_uploads.rb
@@ -1,0 +1,5 @@
+class AddUserIdToUploads < ActiveRecord::Migration
+  def change
+    add_reference :uploads, :user, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150302204412) do
+ActiveRecord::Schema.define(version: 20150313020840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,7 +22,11 @@ ActiveRecord::Schema.define(version: 20150302204412) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string   "meaning"
+    t.string   "meaning_en"
+    t.integer  "user_id"
   end
+
+  add_index "uploads", ["user_id"], name: "index_uploads_on_user_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "name"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,5 +3,16 @@ FactoryGirl.define do
     name "User User"
     first_name "User"
     email "user@example.com"
+    provider "Facebook"
+  end
+
+  factory :upload do
+    url "www.example.com"
+    meaning "manzana"
+    user
+
+    factory :upload_without_meaning do
+      meaning "no meaning"
+    end
   end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
-describe Upload, type: "model"  do
-
+describe Upload, type: "model" do
   it "is invalid without a url" do
     upload = build(:upload, url: nil)
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+describe Upload, type: "model"  do
+
+  it "is invalid without a url" do
+    upload = build(:upload, url: nil)
+
+    expect(upload).not_to be_valid
+  end
+
+  it "is invalid without a meaning" do
+    upload = build(:upload, meaning: nil)
+
+    expect(upload).not_to be_valid
+  end
+
+  it "is invalid without an associated user" do
+    upload = build(:upload, user_id: nil)
+
+    expect(upload).not_to be_valid
+  end
+
+  it "has a method to remove uploads with no meaning" do
+    3.times { create(:upload) }
+    create(:upload_without_meaning)
+
+    expect(Upload.count).to eq(4)
+    expect(Upload.with_meaning.count).to eq(3)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe User, type: "model" do
+  it "is invalid without a name" do
+    user = build(:user, name: nil)
+
+    expect(user).not_to be_valid
+  end
+
+  it "is invalid without a first name" do
+    user = build(:user, first_name: nil)
+
+    expect(user).not_to be_valid
+  end
+
+  it "is invalid without an email" do
+    user = build(:user, email: nil)
+
+    expect(user).not_to be_valid
+  end
+
+  it "is invalid without a provider" do
+    user = build(:user, provider: nil)
+
+    expect(user).not_to be_valid
+  end
+
+  it "has associated uploads" do
+    user = create(:user)
+    3.times { user.uploads << create(:upload) }
+    2.times { create(:upload) }
+
+    expect(Upload.count).to eq(5)
+    expect(user.uploads.count).to eq(3)
+  end
+end


### PR DESCRIPTION
Preparation for showing English meaning alongside Spanish meaning in the game. Changes include:
- Add meaning_en and user_id columns to the uploads table
- Add user tests and validations
- Add upload tests and validations
