### PR TITLE
Add progress bar to new upload page and move export file functionality to lajoya.js

### DIFF
--- a/app/assets/javascripts/lajoya.js
+++ b/app/assets/javascripts/lajoya.js
@@ -19,6 +19,9 @@
         $('#meaning').show();
         $(this).text('Grabar');
         $(this).hide();
+        $('#progressbar').show();
+        $('.progress-value').show();
+        $('.progress-value').text('Espera...Subiendo clip');
         $('#clip-play').show();
       }
 
@@ -69,6 +72,8 @@
       au.src = url;
       li.appendChild(au);
       recordingslist.appendChild(li);
+      sendWaveToPost(blob);
+
     } else { alert('Clip tiene que ser entre 1 y 30 segundos'); }
 
       if(!li){
@@ -78,6 +83,48 @@
         $('#clip-play').hide();
       }
     });
+  }
+
+  function sendWaveToPost(blob) {
+    var data = new FormData();
+    data.append('audio', blob, (new Date()).getTime() + '.mp3');
+
+    var oReq = new XMLHttpRequest();
+    oReq.addEventListener('progress', updateProgress, false);
+    oReq.addEventListener('load', transferComplete, false);
+    oReq.open('POST', '/uploads');
+    oReq.setRequestHeader('X-CSRF-Token',
+      'xobbGEAxrKTnjkzCcIBB69Df391+sMX6pcqp500R9jmutFCeAv69tCVbngovFHvHaiizJRXDP8R1ugfNxdC61Q');
+    oReq.send(data);
+    var startTime = (new Date()).getTime();
+    console.log('Upload started');
+
+      function updateProgress (oEvent) {
+        if (oEvent.lengthComputable) {
+
+        var percentComplete = (oEvent.loaded / oEvent.total) * 100;
+
+        $('#progressbar').val(percentComplete);
+        console.log('progress is now: ' + percentComplete);
+        $('.progress-value').html(percentComplete + '%');
+      } else {
+        alert('Algo no funciona');
+      }
+
+    }
+
+    function transferComplete(evt) {
+      endTime = (new Date()).getTime();
+      alert('The transfer is complete after: ' + (endTime - startTime) / 1000 + ' seconds');
+    }
+
+    oReq.onload = function(oEvent) {
+      if (oReq.status == 200) {
+          console.log('Uploaded');
+      } else {
+          alert('Error ' + oReq.status + ' when uploading your file.');
+      }
+    };
   }
 
   window.onload = function init() {

--- a/app/assets/javascripts/lajoya.js
+++ b/app/assets/javascripts/lajoya.js
@@ -33,8 +33,7 @@
         $('#start-btn').hide();
         $('#meaning').hide();
         $('#warning').show();
-        alert('Favor de usar Chrome, actualizar la página y permitir acceso
-               al micrófono');
+        alert('Favor de usar Chrome, actualizar la página y permitir acceso al micrófono');
       }
     });
 
@@ -93,8 +92,7 @@
     }
 
     navigator.getUserMedia({audio: true}, startUserMedia, function(e) {
-      alert('Favor de usar Chrome, actualizar la página, y permitir acceso
-             al micrófono');
+      alert('Favor de usar Chrome, actualizar la página, y permitir acceso al micrófono');
     });
   };
 })(window);

--- a/app/assets/javascripts/recorder.js
+++ b/app/assets/javascripts/recorder.js
@@ -91,7 +91,7 @@
     var url = (window.URL || window.webkitURL).createObjectURL(blob);
     var link = window.document.createElement('a');
     link.href = url;
-    link.download = filename || 'output.wav';
+    link.download = filename || 'output.mp3';
     var click = document.createEvent("Event");
     click.initEvent("click", true, true);
     link.dispatchEvent(click);

--- a/app/assets/javascripts/recorder.js
+++ b/app/assets/javascripts/recorder.js
@@ -88,6 +88,7 @@
   };
 
   Recorder.forceDownload = function(blob, filename){
+    alert("in forceDownload this is blog" + blob)
     var url = (window.URL || window.webkitURL).createObjectURL(blob);
     var link = window.document.createElement('a');
     link.href = url;

--- a/app/assets/javascripts/recorderWorker.js
+++ b/app/assets/javascripts/recorderWorker.js
@@ -54,7 +54,7 @@ function exportWAV(type){
 
 function sendWaveToPost(blob) {
   var data = new FormData();
-  data.append("audio", blob, (new Date()).getTime() + ".wav");
+  data.append("audio", blob, (new Date()).getTime() + ".mp3");
 
   var oReq = new XMLHttpRequest();
   oReq.open("POST", "/uploads");

--- a/app/assets/javascripts/recorderWorker.js
+++ b/app/assets/javascripts/recorderWorker.js
@@ -48,26 +48,7 @@ function exportWAV(type){
   }
   var dataview = encodeWAV(interleaved);
   var audioBlob = new Blob([dataview], { type: type });
-  sendWaveToPost(audioBlob);
   this.postMessage(audioBlob);
-}
-
-function sendWaveToPost(blob) {
-  var data = new FormData();
-  data.append("audio", blob, (new Date()).getTime() + ".mp3");
-
-  var oReq = new XMLHttpRequest();
-  oReq.open("POST", "/uploads");
-  oReq.setRequestHeader('X-CSRF-Token',
-    "xobbGEAxrKTnjkzCcIBB69Df391+sMX6pcqp500R9jmutFCeAv69tCVbngovFHvHaiizJRXDP8R1ugfNxdC61Q");
-  oReq.send(data);
-  oReq.onload = function(oEvent) {
-      if (oReq.status == 200) {
-          console.log("Uploaded");
-      } else {
-          console.log("Error " + oReq.status + " when uploading your file.");
-      }
-  };
 }
 
 function getBuffer(){

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -157,3 +157,10 @@ li.active > a
   color: $orange2;
   text-decoration: none;
 }
+
+progress {
+  background-color: $white;
+  border: 0;
+  height: 30px;
+  border-radius: 9px;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -151,3 +151,9 @@ li.active > a
 .my-play-button {
   color: $white;
 }
+
+.my-play-button:focus,
+.my-play-button:hover {
+  color: $orange2;
+  text-decoration: none;
+}

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -41,7 +41,8 @@ class UploadsController < ApplicationController
     obj.write(file: params[:audio], acl: :public_read)
     @upload = Upload.new(url: obj.public_url,
                          name: obj.key,
-                         meaning: "no meaning")
+                         meaning: "no meaning",
+                         user_id: current_user.id)
     if @upload.save
       flash[:success] = "File successfully uploaded"
     else

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -2,7 +2,7 @@ class Upload < ActiveRecord::Base
   belongs_to :user
   validates :url, presence: true
   validates :meaning, presence: true
-  validates :user_id, presence: true
+  # validates :user_id, presence: true
 
   def self.with_meaning
     where.not(meaning: ["no meaning", ""])

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -2,7 +2,7 @@ class Upload < ActiveRecord::Base
   belongs_to :user
   validates :url, presence: true
   validates :meaning, presence: true
-  # validates :user_id, presence: true
+  validates :user_id, presence: true
 
   def self.with_meaning
     where.not(meaning: ["no meaning", ""])

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -3,6 +3,8 @@
 <h1>¡Haz clic para escuchar!</h1>
 <div class="table-responsive">
   <% @uploads.each do |upload| %>
-    <p class='my-play-button' data='<%= upload.url %>'><%= upload.meaning %></p>
+    <a href="#" class='my-play-button' data='<%= upload.url %>'>
+      <%= upload.meaning %>
+    </a></br>
   <% end %>
 </div>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -5,6 +5,8 @@
                             y permitir el uso del micrófono</p>
 </p>
 <ul id="recordingslist"></ul>
+<progress id="progressbar" value="0" max="100" hidden=true></progress>
+<h1 class="progress-value big-text" hidden=true></h1>
 <p id="clip-play" hidden=true>Escuchar</p>
 <div id="meaning" hidden=true>
   <h1 class="big-txt">Quiere decir...</h1>


### PR DESCRIPTION
Basic changes to improve UX on new upload and uploads index pages, as well as pulling out custom functionality from recorder.js library.

Changes include:
- Change word meanings to links to show user that they are clickable
- Add a progress bar, as well as a message to show user that their clip is being upload
- When creating an upload, use the current_user's id as the user_id
- Move export file function to lajoya.js (previously in recorderWorker.js, which does not have access to the window).
