### PR TITLE
Add admin functionality; closes #32 and closes #26

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -75,6 +75,19 @@ li {
   margin-top: 7vw;
 }
 
+admin-nav-list > a {
+  font-size: 0.5em;
+  background-color: none;
+  color: $white !important;
+}
+
+a.admin-nav-list-item {
+  font-size: 0.5em;
+  background-color: none;
+  color: $white !important;
+  margin-top: 20px;
+}
+
 a.nav-list-item {
   background-color: none;
   color: $white !important;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -90,11 +90,15 @@ li.active > a
   background-color: $brown !important;
 }
 
+.form {
+  padding: 20px 0;
+}
 .btn {
   border: 0.5vw solid $orange2;
   color: $white;
   font-size: 1.5em;
   text-decoration: none;
+  background-color: $dark-blue2;
 }
 
 .btn:hover {
@@ -113,6 +117,15 @@ li.active > a
 
 .btn-med {
   font-size: 3.5em;
+}
+
+.btn-danger {
+  border: 0.5vw solid $red2;
+  margin-top: 20px;
+}
+
+.btn-danger:hover {
+  background-color: $red2;
 }
 
 #file {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -76,15 +76,14 @@ li {
 }
 
 admin-nav-list > a {
-  font-size: 0.5em;
   background-color: none;
-  color: $white !important;
+  font-size: 2.5em;
 }
 
 a.admin-nav-list-item {
-  font-size: 0.5em;
   background-color: none;
   color: $white !important;
+  font-size: 0.5em;
   margin-top: 20px;
 }
 
@@ -106,9 +105,11 @@ li.active > a
 tr {
   font-size: 0.75em;
 }
+
 .form {
   padding: 20px 0;
 }
+
 .btn {
   border: 0.5vw solid $orange2;
   color: $white;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -90,6 +90,9 @@ li.active > a
   background-color: $brown !important;
 }
 
+tr {
+  font-size: 0.75em;
+}
 .form {
   padding: 20px 0;
 }
@@ -119,9 +122,16 @@ li.active > a
   font-size: 3.5em;
 }
 
+.btn-table {
+  font-size: 1em;
+}
+
+.btn-form {
+  margin: 10px;
+}
+
 .btn-danger {
   border: 0.5vw solid $red2;
-  margin-top: 20px;
 }
 
 .btn-danger:hover {

--- a/app/controllers/api/v1/words_controller.rb
+++ b/app/controllers/api/v1/words_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::WordsController < ApplicationController
   def index
-    @words = Upload.with_meaning.select(:id, :meaning, :meaning_en, :url)
+    @words = Upload.public_words.select(:id, :meaning, :meaning_en, :url)
     render json: @words
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,4 +14,8 @@ class ApplicationController < ActionController::Base
     # flash.now[:error] = "Favor de darle clic en Entrar para seguir"
     redirect_to root_path unless current_user
   end
+
+  def admin_check!
+    redirect_to root_path unless current_user.admin?
+  end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,0 +1,8 @@
+class DashboardsController < ApplicationController
+  before_action :authorize!
+  before_action :admin_check!
+  
+  def show
+    @uploads = Upload.all
+  end
+end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,7 +1,7 @@
 class DashboardsController < ApplicationController
   before_action :authorize!
   before_action :admin_check!
-  
+
   def show
     @uploads = Upload.all
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,11 @@ class SessionsController < ApplicationController
     user = User.find_or_create_from_auth(auth)
     session[:user_id] = user.id if user
 
-    redirect_to home_path
+    if user.admin?
+      redirect_to dashboard_path
+    else
+      redirect_to home_path
+    end
   end
 
   def destroy

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -30,8 +30,7 @@ class UploadsController < ApplicationController
 
   def update
     @upload = Upload.find(params[:id])
-    @upload.update_attributes(meaning: params[:upload][:meaning],
-                              meaning_en: params[:upload][:meaning_en])
+    @upload.update_attributes(upload_params)
 
     redirect_to dashboard_path
   end
@@ -89,5 +88,9 @@ class UploadsController < ApplicationController
         meaning_en: "no meaning"
       }
     end
+  end
+
+  def upload_params
+    params.require(:upload).permit(:meaning, :meaning_en, :active)
   end
 end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,5 +1,6 @@
 class UploadsController < ApplicationController
   before_action :authorize!
+  before_action :admin_check!, only: [:edit, :update, :destroy]
   skip_before_action :verify_authenticity_token
 
   def new
@@ -14,23 +15,42 @@ class UploadsController < ApplicationController
     redirect_to new_upload_path
   end
 
-  def update
+  def edit
+    @upload = Upload.find(params[:id])
+  end
+
+  def add_meaning
     @upload = Upload.last
     @upload.update_attributes(new_meaning_params)
     session[:upload_url] = "#update"
     gon.upload_url = session[:upload_url]
+
     redirect_to new_upload_path
+  end
+
+  def update
+    @upload = Upload.find(params[:id])
+    @upload.update_attributes(meaning: params[:upload][:meaning],
+                              meaning_en: params[:upload][:meaning_en])
+
+    redirect_to dashboard_path
   end
 
   def index
     @uploads = Upload.with_meaning
   end
 
-  def destroy
+  def remove_upload
     Upload.last.delete
     session[:upload_url] = "#destroy"
     gon.upload_url = session[:upload_url]
     redirect_to new_upload_path
+  end
+
+  def destroy
+    Upload.destroy(params[:id])
+
+    redirect_to dashboard_path
   end
 
   private

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -17,4 +17,12 @@ class Upload < ActiveRecord::Base
     self.meaning ||= "no meaning"
     self.meaning_en ||= "no meaning"
   end
+
+  def formatted_created_at
+    self.created_at.strftime("%e/%m/%Y")
+  end
+
+  def formatted_updated_at
+    self.created_at.strftime("%e/%m/%Y")
+  end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -19,10 +19,10 @@ class Upload < ActiveRecord::Base
   end
 
   def formatted_created_at
-    self.created_at.strftime("%e/%m/%Y")
+    created_at.strftime("%e/%m/%Y")
   end
 
   def formatted_updated_at
-    self.created_at.strftime("%e/%m/%Y")
+    created_at.strftime("%e/%m/%Y")
   end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -1,5 +1,6 @@
 class Upload < ActiveRecord::Base
   belongs_to :user
+  before_validation :add_meaning
   validates :url, presence: true
   validates :meaning, presence: true
   validates :user_id, presence: true
@@ -10,5 +11,10 @@ class Upload < ActiveRecord::Base
 
   def self.public_words
     where.not(meaning: ["no meaning", ""]).select(:id, :meaning, :meaning_en, :url)
+  end
+
+  def add_meaning
+    self.meaning ||= "no meaning"
+    self.meaning_en ||= "no meaning"
   end
 end

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,3 +1,5 @@
+<div id="admin">
+<%= render "layouts/admin_nav_bar" %>
 
 <table class="table">
   <thead>
@@ -29,3 +31,4 @@
       </tr>
     <% end %>
 </table>
+</div>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -1,0 +1,20 @@
+
+<table class="table">
+  <thead>
+    <td>Click para esuchar</td>
+    <td>Inglés</td>
+    <td>Usuario</td>
+    <td>Creado</td>
+    <td>Actualizdo</td>
+    </thead>
+    <% @uploads.each do |upload| %>
+      <tr class="word">
+        <td><a href="#" class='my-play-button' data='<%= upload.url %>'>
+          <%= upload.meaning %></a></td>
+        <td><%= upload.meaning_en %></td>
+        <td><%= upload.user_id %></td>
+        <td><%= upload.created_at %></td>
+        <td><%= upload.updated_at %></td>
+      </tr>
+    <% end %>
+</table>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -15,6 +15,7 @@
         <td><%= upload.user_id %></td>
         <td><%= upload.created_at %></td>
         <td><%= upload.updated_at %></td>
+        <td> <%= link_to "Editar", edit_upload_path(upload.id) %></td>
       </tr>
     <% end %>
 </table>

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -13,9 +13,19 @@
           <%= upload.meaning %></a></td>
         <td><%= upload.meaning_en %></td>
         <td><%= upload.user_id %></td>
-        <td><%= upload.created_at %></td>
-        <td><%= upload.updated_at %></td>
-        <td> <%= link_to "Editar", edit_upload_path(upload.id) %></td>
+        <td><%= upload.formatted_created_at %></td>
+        <td><%= upload.formatted_updated_at %></td>
+        <% if upload.active? %>
+          <td><%= link_to "Desactivar",
+            upload_path(upload, upload: { active: false }), method: :patch,
+            class: "btn btn-table btn-danger" %>
+        <% else %>
+          <td><%= link_to "Activar",
+            upload_path(upload, upload: { active: true }), method: :patch,
+            class: "btn btn-table" %>
+        <% end %>
+        <td><%= link_to "Editar", edit_upload_path(upload.id),
+          class: "btn btn-table"%></td>
       </tr>
     <% end %>
 </table>

--- a/app/views/layouts/_admin_nav_bar.html.erb
+++ b/app/views/layouts/_admin_nav_bar.html.erb
@@ -1,0 +1,15 @@
+<navbar>
+<%= nav_bar fixed: :top, responsive: true do %>
+  <div class="admin-nav-list">
+    <%= menu_group inline: true do %>
+      <%= menu_item image_tag("goat-walking4.png", alt: "goat-logo", size: "50x50"), home_path, class:"nav-list-image" %>
+      <%= menu_item "Di", new_upload_path, class:"admin-nav-list-item" %>
+      <%= menu_item "Escucha", uploads_path, class:"admin-nav-list-item" %>
+      <%= menu_item "Adivina", new_game_path, class:"admin-nav-list-item" %>
+    <% end %>
+    <%= menu_group pull: :right do %>
+      <%= menu_item "Salir", logout_path, class:"admin-nav-list-item" %>
+    <% end %>
+  </div>
+<% end %>
+</navbar>

--- a/app/views/layouts/_full_nav_bar.html.erb
+++ b/app/views/layouts/_full_nav_bar.html.erb
@@ -2,7 +2,7 @@
 <%= nav_bar fixed: :top, responsive: true do %>
   <div class="nav-list">
     <%= menu_group inline: true do %>
-      <%= menu_item image_tag("goat-walking4.png", size: "125x125"), home_path, class:"nav-list-image" %>
+      <%= menu_item image_tag("goat-walking4.png", alt: "goat-logo", size: "125x125"), home_path, class:"nav-list-image" %>
       <%= menu_item "Di", new_upload_path, class:"nav-list-item" %>
       <%= menu_item "Escucha", uploads_path, class:"nav-list-item" %>
       <%= menu_item "Adivina", new_game_path, class:"nav-list-item" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,19 +12,13 @@
   </head>
   <body>
     <div class="main-body container">
-      <!-- <div
-        class="fb-like"
-        data-share="true"
-        data-width="450"
-        data-show-faces="true">
-      </div> -->
-      <div class="flash-messages">
-        <% flash.each do |name, message| %>
-          <div class=name>
-            <%= message %>
-          </div>
-        <% end %>
+
+    <% flash.each do |name, message| %>
+      <div class="flash-messages <%= name %>">
+        <%= message %>
       </div>
+    <% end %>
+
     <%= yield %>
 
     <div>

--- a/app/views/uploads/edit.html.erb
+++ b/app/views/uploads/edit.html.erb
@@ -1,3 +1,4 @@
+<%= render "layouts/admin_nav_bar" %>
 <h2>Editar clip</h2>
 <div class=row>
   <div class="col-md-8 col-md-offset-2">

--- a/app/views/uploads/edit.html.erb
+++ b/app/views/uploads/edit.html.erb
@@ -1,0 +1,20 @@
+<h2>Editar clip</h2>
+<div class=row>
+  <div class="col-md-8 col-md-offset-2">
+    <audio class="clip">
+      <source id="clip-source" src=<%= @upload.url %>></source>
+    </audio>
+    <p id="clip-play" class="btn btn-form">Escuchar</p>
+  </div>
+  <div class="form">
+    <%= bootstrap_form_for(@upload) do |f| %>
+      <%= f.text_field :meaning, label: "significado" %>
+      <%= f.text_field :meaning_en, label: "inglés" %>
+      <%= f.submit "Guardar", class: "btn btn-form" %>
+      <%= link_to "Cancelar", dashboard_path, class: "btn btn-form" %></br>
+      <%= link_to "Eliminar", upload_path(@upload),
+        { method: :delete, class:"btn btn-danger",
+          data: { confirm: "¿Seguro que quieres eliminar el clip?" }} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -12,12 +12,12 @@
     <source id="clip-source" src= <%= session[:upload_url] %>></source>
   </audio>
   <a href="#" id="clip-play" class="btn btn-width" hidden=true>Escuchar</a>
-  <%=form_tag(upload_path("1"), method: "patch") do %>
+  <%=form_tag(add_meaning_path("1"), method: "patch") do %>
     <%= text_field_tag :meaning, nil,
                        placeholder: "significado",
                        class: "btn btn-width txt-box" %></br>
     <p><%= submit_tag "Guardar", class:"btn btn-width" %></p>
-    <p> <%= link_to "Cancelar", upload_path("1"), { method: :delete, class:"btn btn-width" } %>
+    <p><%= link_to "Cancelar", remove_upload_path, { method: :delete, class:"btn btn-width" } %>
   <% end %>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get "/auth/facebook/callback", to: "sessions#create"
   get "/logout", to: "sessions#destroy"
   patch "/add_meaning", to: "uploads#add_meaning"
-  get "/remove_upload", to: "uploads#remove_upload"
+  delete "/remove_upload", to: "uploads#remove_upload"
   resources :uploads
   resources :games, only: [:new, :update]
   resource :dashboard, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get "/logout", to: "sessions#destroy"
   patch "/add_meaning", to: "uploads#add_meaning"
   delete "/remove_upload", to: "uploads#remove_upload"
-  resources :uploads
+  resources :uploads, except: [:show]
   resources :games, only: [:new, :update]
   resource :dashboard, only: [:show]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   get "/home", to: "static_pages#home"
   get "/auth/facebook/callback", to: "sessions#create"
   get "/logout", to: "sessions#destroy"
+  patch "/add_meaning", to: "uploads#add_meaning"
+  get "/remove_upload", to: "uploads#remove_upload"
   resources :uploads
   resources :games, only: [:new, :update]
   resource :dashboard, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get "/logout", to: "sessions#destroy"
   resources :uploads
   resources :games, only: [:new, :update]
+  resource :dashboard, only: [:show]
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do

--- a/db/migrate/20150317193354_add_admin_to_users.rb
+++ b/db/migrate/20150317193354_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/migrate/20150317232028_add_active_to_uploads.rb
+++ b/db/migrate/20150317232028_add_active_to_uploads.rb
@@ -1,0 +1,5 @@
+class AddActiveToUploads < ActiveRecord::Migration
+  def change
+    add_column :uploads, :active, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150317193354) do
+ActiveRecord::Schema.define(version: 20150317232028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,11 +19,12 @@ ActiveRecord::Schema.define(version: 20150317193354) do
   create_table "uploads", force: :cascade do |t|
     t.string   "url"
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
     t.string   "meaning"
     t.string   "meaning_en"
     t.integer  "user_id"
+    t.boolean  "active",     default: false
   end
 
   add_index "uploads", ["user_id"], name: "index_uploads_on_user_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150313020840) do
+ActiveRecord::Schema.define(version: 20150317193354) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,8 +36,9 @@ ActiveRecord::Schema.define(version: 20150313020840) do
     t.string   "token"
     t.string   "uid"
     t.string   "profile_image_url"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.boolean  "admin",             default: false
   end
 
 end

--- a/spec/controllers/uploads_spec.rb
+++ b/spec/controllers/uploads_spec.rb
@@ -53,21 +53,21 @@ RSpec.describe UploadsController do
       post :create, { audio: file_to_upload }
 
       expect {
-        delete :destroy, id: Upload.last
+        delete :remove_upload, id: Upload.last
       }.to change{ Upload.count }.by(-1)
       expect(response).to redirect_to(new_upload_path)
       expect(flash[:error]).not_to be_present
     end
   end
 
-  describe "#update" do
-    it "updates the upload" do
+  describe "#add_meaning" do
+    it "adds meaning to the upload" do
       user = create(:user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).
         and_return(user)
       post :create, { audio: file_to_upload }
 
-      put :update, id: Upload.last, meaning: "perro"
+      put :add_meaning, id: Upload.last, meaning: "perro"
       upload = Upload.last
 
       expect(upload.meaning).to eq("perro")

--- a/spec/integration/admin_dashboard_spec.rb
+++ b/spec/integration/admin_dashboard_spec.rb
@@ -44,12 +44,12 @@ describe "an admin", type: :feature do
       uploads.each do |upload|
         expect(page).to have_content(upload.user_id)
         expect(page).to have_content(upload.meaning_en)
-        expect(page).to have_content(upload.created_at)
-        expect(page).to have_content(upload.updated_at)
+        expect(page).to have_content(upload.formatted_created_at)
+        expect(page).to have_content(upload.formatted_updated_at)
       end
     end
 
-    it "can see a button to edit each upload" do
+    it "can see a button to activate and edit each upload" do
       admin = create(:user, admin: true)
       allow_any_instance_of(ApplicationController).to receive(:current_user).
         and_return(admin)
@@ -61,6 +61,7 @@ describe "an admin", type: :feature do
 
       visit dashboard_path
 
+      expect(page).to have_link("Activar", count: 20)
       expect(page).to have_link("Editar", count: 20)
     end
 
@@ -78,6 +79,19 @@ describe "an admin", type: :feature do
       first(:link, "Editar").click
 
       expect(current_path).to eq(edit_upload_path(uploads.first))
+    end
+
+    it "can activate an upload" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+      upload = create(:upload)
+
+      visit dashboard_path
+      first(:link, "Activar").click
+
+      expect(current_path).to eq(dashboard_path)
+      expect(Upload.find(upload.id).active?).to be_truthy
     end
   end
 end

--- a/spec/integration/admin_dashboard_spec.rb
+++ b/spec/integration/admin_dashboard_spec.rb
@@ -29,7 +29,7 @@ describe "an admin", type: :feature do
       expect(page).to have_css("tr.word", count: 20)
     end
 
-    it "can details for each upload" do
+    it "can see details for each upload" do
       admin = create(:user, admin: true)
       allow_any_instance_of(ApplicationController).to receive(:current_user).
         and_return(admin)
@@ -49,5 +49,35 @@ describe "an admin", type: :feature do
       end
     end
 
+    it "can see a button to edit each upload" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+      uploads = []
+      10.times do
+        uploads << create(:upload)
+        uploads << create(:upload_without_meaning)
+      end
+
+      visit dashboard_path
+
+      expect(page).to have_link("Editar", count: 20)
+    end
+
+    it "can click a button and be taken to the edit upload page" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+      uploads = []
+      10.times do
+        uploads << create(:upload)
+        uploads << create(:upload_without_meaning)
+      end
+
+      visit dashboard_path
+      first(:link, "Editar").click
+
+      expect(current_path).to eq(edit_upload_path(uploads.first))
+    end
   end
 end

--- a/spec/integration/admin_dashboard_spec.rb
+++ b/spec/integration/admin_dashboard_spec.rb
@@ -93,5 +93,60 @@ describe "an admin", type: :feature do
       expect(current_path).to eq(dashboard_path)
       expect(Upload.find(upload.id).active?).to be_truthy
     end
+
+    xit "can click on the link to the home page" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+
+      visit dashboard_path
+      page.find("img[@alt='goat-logo']").click
+
+      expect(current_path).to eq(home_path)
+    end
+
+    it "can click on the link to the Di page" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+
+      visit dashboard_path
+      click_link("Di")
+
+      expect(current_path).to eq(new_upload_path)
+    end
+
+    it "can click on the link to the Escucha page" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+
+      visit dashboard_path
+      click_link("Escucha")
+
+      expect(current_path).to eq(uploads_path)
+    end
+
+    it "can click on the link to the Adivina page" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+
+      visit dashboard_path
+      click_link("Adivina")
+
+      expect(current_path).to eq(new_game_path)
+    end
+
+    it "can click on the link to logout" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+
+      visit dashboard_path
+      click_link("Salir")
+
+      expect(current_path).to eq(root_path)
+    end
   end
 end

--- a/spec/integration/admin_dashboard_spec.rb
+++ b/spec/integration/admin_dashboard_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe "an admin", type: :feature do
+  describe "after logging in" do
+    include Capybara::DSL
+
+    it "can visit the admin dashboard" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+
+      visit dashboard_path
+
+      expect(current_path).to eq(dashboard_path)
+    end
+
+    it "can see all the uploads" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+      uploads = []
+      10.times do
+        uploads << create(:upload)
+        uploads << create(:upload_without_meaning)
+      end
+
+      visit dashboard_path
+
+      expect(page).to have_css("tr.word", count: 20)
+    end
+
+    it "can details for each upload" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+        and_return(admin)
+      uploads = []
+      10.times do
+        uploads << create(:upload)
+        uploads << create(:upload_without_meaning)
+      end
+
+      visit dashboard_path
+
+      uploads.each do |upload|
+        expect(page).to have_content(upload.user_id)
+        expect(page).to have_content(upload.meaning_en)
+        expect(page).to have_content(upload.created_at)
+        expect(page).to have_content(upload.updated_at)
+      end
+    end
+
+  end
+end

--- a/spec/integration/edit_upload_spec.rb
+++ b/spec/integration/edit_upload_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe "an upload", type: :feature do
+    include Capybara::DSL
+
+  it "can be updated" do
+    admin = create(:user, admin: true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(admin)
+    upload = create(:upload)
+    old_meaning = upload.meaning
+
+    visit edit_upload_path(upload)
+    fill_in("significado", with: "chivo")
+    fill_in("inglés", with: "goat")
+    click_link_or_button("Guardar")
+
+    expect(current_path).to eq(dashboard_path)
+    expect(page).not_to have_content(old_meaning)
+    expect(page).to have_content("chivo")
+    expect(page).to have_content("goat")
+  end
+
+  it "can be have the changes cancelled" do
+    admin = create(:user, admin: true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(admin)
+    upload = create(:upload)
+    old_meaning = upload.meaning
+
+    visit edit_upload_path(upload)
+    fill_in("significado", with: "chivo")
+    fill_in("inglés", with: "goat")
+    click_link_or_button("Cancelar")
+
+    expect(current_path).to eq(dashboard_path)
+    expect(page).to have_content(old_meaning)
+    expect(page).not_to have_content("chivo")
+    expect(page).not_to have_content("goat")
+  end
+end

--- a/spec/integration/edit_upload_spec.rb
+++ b/spec/integration/edit_upload_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "an upload", type: :feature do
-    include Capybara::DSL
+  include Capybara::DSL
 
   it "can be updated" do
     admin = create(:user, admin: true)
@@ -47,9 +47,9 @@ describe "an upload", type: :feature do
 
     visit edit_upload_path(upload)
 
-    expect{ click_link_or_button("Eliminar") }
-      .to change{ Upload.count }.by(-1)
-      
+    expect { click_link_or_button("Eliminar") }
+      .to change { Upload.count }.by(-1)
+
     expect(current_path).to eq(dashboard_path)
     expect(page).not_to have_content(upload.meaning)
   end

--- a/spec/integration/edit_upload_spec.rb
+++ b/spec/integration/edit_upload_spec.rb
@@ -38,4 +38,19 @@ describe "an upload", type: :feature do
     expect(page).not_to have_content("chivo")
     expect(page).not_to have_content("goat")
   end
+
+  it "can be deleted" do
+    admin = create(:user, admin: true)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(admin)
+    upload = create(:upload)
+
+    visit edit_upload_path(upload)
+
+    expect{ click_link_or_button("Eliminar") }
+      .to change{ Upload.count }.by(-1)
+      
+    expect(current_path).to eq(dashboard_path)
+    expect(page).not_to have_content(upload.meaning)
+  end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -7,10 +7,10 @@ describe Upload, type: "model" do
     expect(upload).not_to be_valid
   end
 
-  it "is invalid without a meaning" do
-    upload = build(:upload, meaning: nil)
+  it "is has a default meaning" do
+    upload = create(:upload, meaning: nil)
 
-    expect(upload).not_to be_valid
+    expect(upload.meaning).to eq("no meaning")
   end
 
   it "is invalid without an associated user" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,4 +33,18 @@ describe User, type: "model" do
     expect(Upload.count).to eq(5)
     expect(user.uploads.count).to eq(3)
   end
+
+  it "is not an admin by default" do
+    user = create(:user)
+
+    expect(user.admin?).to be_falsey
+  end
+
+  it "is be an admin" do
+    user = create(:user)
+
+    user.update_attributes(admin: true)
+
+    expect(user.admin?).to be_truthy
+  end
 end

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -1,82 +1,71 @@
-require 'rails_helper'
+require "rails_helper"
 
-describe 'uploads' do
+describe "uploads" do
   let(:upload) { create(:upload) }
 
-  context 'logged in user' do
-    before { user = create(:user)
+  context "logged in user" do
+    before(:each) do
+      user = create(:user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).
-      and_return(user) }
+        and_return(user)
+    end
 
-    it 'DELETE /uploads/:id' do
+    it "DELETE /uploads/:id" do
+      upload = create(:upload)
       delete upload_path(upload)
+
+      expect(Upload.count).to eq(1)
       expect(response.status).to eq 302
     end
   end
 
-  context 'an admin' do
-    before { create(:user)
+  context "an admin" do
+    before (:each) do
+      admin = create(:user, admin: true)
       allow_any_instance_of(ApplicationController).to receive(:current_user).
-      and_return(user) }
-
-    context 'company not yet created' do
-      xit 'GET /v1/companies/:id' do
-        get v1_company_path(product.id), {}
-        expect(response.status).to eq 200
-        expect(response.json['company']['id']).to eq product.id
-        expect(response.json['company']['legal_name']).to be_blank
-      end
-
-      xit 'PUT /v1/companies/:id' do
-        params = {company: {legal_name: 'DesignBook, LLC'}}
-        put v1_company_path(product.id), params
-        expect(response.status).to eq 200
-        expect(response.json['company']['id']).to eq product.id
-        expect(response.json['company']['legal_name']).to eq 'DesignBook, LLC'
-      end
+        and_return(admin)
     end
 
-    context 'pre-existing company' do
-      before { Company.create(legal_name: 'foo', product: product) }
+    it "DELETE /uploads/:id" do
+      delete "/uploads/#{upload.id}"
 
-      xit 'GET /v1/companies/:id' do
-        get v1_company_path(product.id), {}
-        expect(response.status).to eq 200
-        expect(response.json['company']['id']).to eq product.id
-        expect(response.json['company']['legal_name']).to eq 'foo'
-      end
+      expect(response.status).to eq 302
+      expect(Upload.count).to eq(0)
+      expect(response).not_to be_success
     end
   end
 
-  context 'user w/o access' do
-    it 'GET /uploads' do
+  context "user w/o access" do
+    it "GET /uploads" do
       get uploads_path, {}
       expect(response.status).to eq 302
     end
 
-    it 'POST /uploads' do
-      post uploads_path, { audio: file_to_upload }
+    it "POST /uploads" do
+      post uploads_path, audio: file_to_upload
       expect(response.status).to eq 302
     end
 
-    it 'GET /uploads/new' do
+    it "GET /uploads/new" do
       get new_upload_path, {}
       expect(response.status).to eq 302
     end
 
-    it 'GET /uploads/:id/edit' do
+    it "GET /uploads/:id/edit" do
       get edit_upload_path(upload), {}
       expect(response.status).to eq 302
     end
 
-    it 'PUT /uploads/:id' do
-      put upload_path(upload), { meaning: "perro" }
+    it "PUT /uploads/:id" do
+      put upload_path(upload), meaning: "perro"
       expect(response.status).to eq 302
     end
 
-    it 'DELETE /uploads/:id' do
+    it "DELETE /uploads/:id" do
       delete upload_path(upload)
+
       expect(response.status).to eq 302
+      expect(Upload.count).to eq(1)
     end
   end
 

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+describe 'uploads' do
+  let(:upload) { create(:upload) }
+
+  context 'logged in user' do
+    before { user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(user) }
+
+    it 'DELETE /uploads/:id' do
+      delete upload_path(upload)
+      expect(response.status).to eq 302
+    end
+  end
+
+  context 'an admin' do
+    before { create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).
+      and_return(user) }
+
+    context 'company not yet created' do
+      xit 'GET /v1/companies/:id' do
+        get v1_company_path(product.id), {}
+        expect(response.status).to eq 200
+        expect(response.json['company']['id']).to eq product.id
+        expect(response.json['company']['legal_name']).to be_blank
+      end
+
+      xit 'PUT /v1/companies/:id' do
+        params = {company: {legal_name: 'DesignBook, LLC'}}
+        put v1_company_path(product.id), params
+        expect(response.status).to eq 200
+        expect(response.json['company']['id']).to eq product.id
+        expect(response.json['company']['legal_name']).to eq 'DesignBook, LLC'
+      end
+    end
+
+    context 'pre-existing company' do
+      before { Company.create(legal_name: 'foo', product: product) }
+
+      xit 'GET /v1/companies/:id' do
+        get v1_company_path(product.id), {}
+        expect(response.status).to eq 200
+        expect(response.json['company']['id']).to eq product.id
+        expect(response.json['company']['legal_name']).to eq 'foo'
+      end
+    end
+  end
+
+  context 'user w/o access' do
+    it 'GET /uploads' do
+      get uploads_path, {}
+      expect(response.status).to eq 302
+    end
+
+    it 'POST /uploads' do
+      post uploads_path, { audio: file_to_upload }
+      expect(response.status).to eq 302
+    end
+
+    it 'GET /uploads/new' do
+      get new_upload_path, {}
+      expect(response.status).to eq 302
+    end
+
+    it 'GET /uploads/:id/edit' do
+      get edit_upload_path(upload), {}
+      expect(response.status).to eq 302
+    end
+
+    it 'PUT /uploads/:id' do
+      put upload_path(upload), { meaning: "perro" }
+      expect(response.status).to eq 302
+    end
+
+    it 'DELETE /uploads/:id' do
+      delete upload_path(upload)
+      expect(response.status).to eq 302
+    end
+  end
+
+  def file_to_upload
+    ActionDispatch::Http::UploadedFile.new(
+      type: "audio/wav",
+      head: "Content-Disposition: form-data; name=\"audio\"; "\
+        "filename=\"1426362615855.mp3\"\r\nContent-Type: audio/wav\r\n",
+      filename: "1426362615855.mp3",
+      tempfile: File.new("#{Rails.root}/spec/fixtures/test_clip.wav")
+    )
+  end
+end

--- a/spec/routing/dashboard_spec.rb
+++ b/spec/routing/dashboard_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe "dashboard page" do
+  include Capybara::DSL
+
+  context "user not logged in" do
+    it "visits dashboard_path" do
+      visit dashboard_path
+
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "user logged in" do
+    it "visits dashboard_path" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).and_return(user)
+
+      visit dashboard_path
+
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "admin logged in" do
+    it "visits dashboard_path" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).and_return(admin)
+
+      visit dashboard_path
+
+      expect(current_path).to eq(dashboard_path)
+    end
+  end
+end

--- a/spec/routing/game_spec.rb
+++ b/spec/routing/game_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe "new game page" do
+  include Capybara::DSL
+
+  context "user not logged in" do
+    it "visits new_game_path" do
+      visit new_game_path
+
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "user logged in" do
+    it "visits new_game_path" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).and_return(user)
+
+      visit new_game_path
+
+      expect(current_path).to eq(new_game_path)
+    end
+  end
+
+  context "admin logged in" do
+    it "visits dashboard_path" do
+      admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).and_return(admin)
+
+      visit new_game_path
+
+      expect(current_path).to eq(new_game_path)
+    end
+  end
+end

--- a/spec/routing/guest_spec.rb
+++ b/spec/routing/guest_spec.rb
@@ -34,32 +34,3 @@ describe "home page" do
     end
   end
 end
-
-describe "uploads pages" do
-  include Capybara::DSL
-
-  context "user not logged in" do
-    it "visits uploads_path" do
-      visit uploads_path
-      expect(current_path).to eq root_path
-    end
-
-    it "visits new_upload_path" do
-      visit new_upload_path
-      expect(current_path).to eq root_path
-    end
-  end
-
-  context "user logged in" do
-    before(:each) do
-      user = create(:user)
-      allow_any_instance_of(ApplicationController).
-        to receive(:current_user).and_return(user)
-    end
-
-    it "visits new_upload_path" do
-      visit new_upload_path
-      expect(current_path).to eq new_upload_path
-    end
-  end
-end

--- a/spec/routing/uploads_spec.rb
+++ b/spec/routing/uploads_spec.rb
@@ -1,0 +1,79 @@
+require "spec_helper"
+
+describe "the uploads" do
+  include Capybara::DSL
+
+  context "user not logged in" do
+    it "visits uploads_path" do
+      visit uploads_path
+
+      expect(current_path).to eq(root_path)
+    end
+
+    it "visits new_upload_path" do
+      visit new_upload_path
+
+      expect(current_path).to eq(root_path)
+    end
+
+    it "visits edit_upload_path" do
+      upload = create(:upload)
+
+      visit edit_upload_path(id: upload.id)
+
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "user logged in" do
+    before { user = create(:user)
+      allow_any_instance_of(ApplicationController).
+      to receive(:current_user).and_return(user) }
+
+    it "visits dashboard_path" do
+      visit dashboard_path
+
+      expect(current_path).to eq(root_path)
+    end
+
+    it "visits new_upload_path" do
+      visit new_upload_path
+
+      expect(current_path).to eq(new_upload_path)
+    end
+
+    it "visits edit_upload_path" do
+      upload = create(:upload)
+
+      visit edit_upload_path(id: upload.id)
+
+      expect(current_path).to eq(root_path)
+    end
+  end
+
+  context "admin logged in" do
+    before { admin = create(:user, admin: true)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).and_return(admin) }
+
+    it "visits dashboard_path" do
+      visit dashboard_path
+
+      expect(current_path).to eq(dashboard_path)
+    end
+
+    it "visits new_upload_path" do
+      visit new_upload_path
+
+      expect(current_path).to eq(new_upload_path)
+    end
+
+    it "visits edit_upload_path" do
+      upload = create(:upload)
+
+      visit edit_upload_path(upload)
+
+      expect(current_path).to eq(edit_upload_path(upload))
+    end
+  end
+end

--- a/spec/routing/uploads_spec.rb
+++ b/spec/routing/uploads_spec.rb
@@ -26,9 +26,11 @@ describe "the uploads" do
   end
 
   context "user logged in" do
-    before { user = create(:user)
+    before(:each) do
+      user = create(:user)
       allow_any_instance_of(ApplicationController).
-      to receive(:current_user).and_return(user) }
+        to receive(:current_user).and_return(user)
+    end
 
     it "visits dashboard_path" do
       visit dashboard_path
@@ -52,9 +54,11 @@ describe "the uploads" do
   end
 
   context "admin logged in" do
-    before { admin = create(:user, admin: true)
+    before(:each) do
+      admin = create(:user, admin: true)
       allow_any_instance_of(ApplicationController).
-        to receive(:current_user).and_return(admin) }
+        to receive(:current_user).and_return(admin)
+    end
 
     it "visits dashboard_path" do
       visit dashboard_path

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require "support/factory_girl"
 require "simplecov"
 require "rack_session_access/capybara"
 
-SimpleCov.start
+SimpleCov.start "rails"
 
 OmniAuth.config.test_mode = true
 


### PR DESCRIPTION
This adds basic admin functionality--admin can view all uploads, update meanings in English and Spanish,  activated, deactivate, and delete uploads.

Changes include:
- Add dashboard page
- Add edit upload page
- Add admin column to users table
- Add active column to uploads table
